### PR TITLE
Add Google's MorphNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Hyper-parameter optimization has always been a popular field in the Machine Lear
   - Haifeng Jin, Qingquan Song, Xia Hu. *Arxiv 1806*
 - Searching for Efficient Multi-Scale Architectures for Dense Image Prediction [[pdf]](https://arxiv.org/abs/1809.04184) 
   - Liang-Chieh Chen, Maxwell D. Collins, Yukun Zhu, George Papandreou, Barret Zoph, Florian Schroff, Hartwig Adam, Jonathon Shlens. *Arxiv 1809*
+- MorphNet: Fast & Simple Resource-Constrained Structure Learning of Deep Networks [[pdf]](http://openaccess.thecvf.com/content_cvpr_2018/papers/Gordon_MorphNet_Fast__CVPR_2018_paper.pdf)
+  - Ariel Gordon, Elad Eban, Bo Chen, Ofir Nachum, Tien-Ju Yang, Edward Choi. *CVPR'2018*
 
 
 ## Hyper-Parameter Search

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Hyper-parameter optimization has always been a popular field in the Machine Lear
 - Searching for Efficient Multi-Scale Architectures for Dense Image Prediction [[pdf]](https://arxiv.org/abs/1809.04184) 
   - Liang-Chieh Chen, Maxwell D. Collins, Yukun Zhu, George Papandreou, Barret Zoph, Florian Schroff, Hartwig Adam, Jonathon Shlens. *Arxiv 1809*
 - MorphNet: Fast & Simple Resource-Constrained Structure Learning of Deep Networks [[pdf]](http://openaccess.thecvf.com/content_cvpr_2018/papers/Gordon_MorphNet_Fast__CVPR_2018_paper.pdf)
-  - Ariel Gordon, Elad Eban, Bo Chen, Ofir Nachum, Tien-Ju Yang, Edward Choi. *CVPR'2018*
+  - Ariel Gordon, Elad Eban, Bo Chen, Ofir Nachum, Tien-Ju Yang, Edward Choi. *CVPR'18*
 
 
 ## Hyper-Parameter Search


### PR DESCRIPTION
Full paper title:
> MorphNet: Fast & Simple Resource-Constrained Structure Learning of Deep Networks

See [here](https://ai.googleblog.com/2018/06/google-at-cvpr-2018.html) for more papers